### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: github-actions
     directories:
       - "/"
-      - "/.github/actions/setup-devenv"
+      - "/.github/actions/*"
     schedule:
       interval: weekly
   - package-ecosystem: npm


### PR DESCRIPTION
This pull request makes a small update to the Dependabot configuration, broadening the scope of GitHub Actions directories that Dependabot will monitor for updates.

- Changed the `directories` entry for the `github-actions` ecosystem from only `/.github/actions/setup-devenv` to all subdirectories under `/.github/actions/*` in `.github/dependabot.yml`, ensuring Dependabot checks all actions for updates.